### PR TITLE
feat: remove 'monthly' button

### DIFF
--- a/br/templates/br/dashboard.html
+++ b/br/templates/br/dashboard.html
@@ -71,17 +71,7 @@
                 {% endfor %}
                 </div>
             </li>
-            <li class="nav-item">
-                <ul class="nav nav-pills">
-                    {% if cumulative %}
-                    <li class="nav-item"><a class="nav-link active" id="cumulative" href="#">Cumulative</a></li>
-                    <li class="nav-item"><a class="nav-link" id="monthly" href="#">Monthly</a></li>
-                    {% else %}
-                    <li class="nav-item"><a class="nav-link" id="cumulative" href="#">Cumulative</a></li>
-                    <li class="nav-item"><a class="nav-link active" id="monthly" href="#">Monthly</a></li>
-                    {% endif %}
-                </ul>
-            </li>
+            <li class="nav-item"><a class="nav-link" id="cumulative" href="#">Cumulative</a></li>
             <li class="nav-item"><a class="nav-link" href="https://staging.rapidsmsnigeria.org/br">Coverage</a></li>
             <li class="nav-item">
                 <form action="{{ request.get_full_path }}" method="GET" id="export"><input type="hidden" name="export" value="✓">{% if cumulative %}<input type="hidden" name="cumulative" value="1">{% endif %}<a href="javascript:;" id="export_button" class="nav-link">Export</a></form>


### PR DESCRIPTION
this pull request addresses #11 by removing the 'Monthly' button.
an unforseen consequence of this is that by selecting a year,
then clicking the 'Cumulative' button, one can view the
cumulative reporting up to that year, so clicking on the link
for 2016, then on the 'Cumulative' button will show the
cumulative reporting up to and including 2016.

see: #11