### PR TITLE
fix: patch issues with empty prior dataframes

### DIFF
--- a/br/api/utils.py
+++ b/br/api/utils.py
@@ -169,13 +169,29 @@ def get_api_data(level='country', year=None, month=None):
                 year=year,
                 month=month
             )
-            data.update(previous=[{
-                'year': year,
-                'u1_perf': round(alt_df.loc[loc_id]['u1_perf'] * 100, 2),
-                'u5_perf': round(alt_df.loc[loc_id]['u5_perf'] * 100, 2),
-                'u1_estimate': round(alt_df.loc[loc_id]['u1_estimate']),
-                'u5_estimate': round(alt_df.loc[loc_id]['u5_estimate']),
-            } for year, alt_df in zip(years, alt_dataframes)])
+
+            previous = []
+            for year, alt_df in zip(years, alt_dataframes):
+                try:
+                    subset = alt_df.loc[loc_id]
+
+                    previous.append({
+                        'year': year,
+                        'u1_perf': round(subset['u1_perf'] * 100, 2),
+                        'u5_perf': round(subset['u5_perf'] * 100, 2),
+                        'u1_estimate': round(subset['u1_estimate'] * 100, 2),
+                        'u5_estimate': round(subset['u5_estimate'] * 100, 2),
+                    })
+                except KeyError:
+                    previous.append({
+                        'year': year,
+                        'u1_perf': 0,
+                        'u5_perf': 0,
+                        'u1_estimate': 0,
+                        'u5_estimate': 0,
+                    })
+
+            data.update(previous=previous)
             feature['properties'].update(data)
 
     return payload


### PR DESCRIPTION
as the title describes, it's possible to not have data reported, particularly in the early years of the RapidSMS program. this provides sane defaults (0)