### PR TITLE
Reporter location fix

### DIFF
--- a/br/views.py
+++ b/br/views.py
@@ -184,7 +184,10 @@ def _state_dashboard(request, location, year, month, cumulative):
         prior_u1 = grouped_sum_df['prior_u1'].sum()
         u1_estimate = grouped_sum_df['u1_estimate'].sum()
         u5_estimate = grouped_sum_df['u5_estimate'].sum()
-        u1_performance = round(summary_data['u1'] * 100 / u1_estimate)
+        try:
+            u1_performance = round(summary_data['u1'] * 100 / u1_estimate)
+        except ZeroDivisionError:
+            u1_performance = 0
         u5_performance = round(
             (summary_data['u5'] + prior_u1) * 100 / u5_estimate)
     else:

--- a/reporters/models.py
+++ b/reporters/models.py
@@ -142,10 +142,7 @@ class Reporter(models.Model):
                 identity=connection.identity)
             # this currently checks first and last name, location and role.
             # we may want to make this more lax
-            filters = {"first_name": reporter.first_name,
-                       "last_name": reporter.last_name,
-                       "location": reporter.location,
-                       "role": reporter.role}
+            filters = {"location": reporter.location, "role": reporter.role}
             existing_reps = Reporter.objects.filter(**filters)
             if existing_conn.reporters.filter(pk__in=existing_reps).exists():
                 return True


### PR DESCRIPTION
This pull request makes the reporter existence lookup more lax, by requiring only a match for the phone number, location and role, and not the first and last name