### PR TITLE
feat: extract VRP base URL as a setting

### DIFF
--- a/unicefng/settings.py
+++ b/unicefng/settings.py
@@ -381,3 +381,4 @@ SWAGGER_SETTINGS = {
 # VitalRegPro REST API settings
 VRP_USER_ID = config('VRP_USER_ID')
 VRP_PASSWORD = config('VRP_PASSWORD')
+VRP_BASE_URL = config('VRP_BASE_URL', default='https://vital.npcng.com')


### PR DESCRIPTION
this PR extracts the URL for the VRP API server into a setting, named `VRP_BASE_URL`. all other endpoints are grafted onto it, so to speak.